### PR TITLE
Default fe RUNTIME_CONFIG

### DIFF
--- a/frontend/public/runtime/config.js
+++ b/frontend/public/runtime/config.js
@@ -1,4 +1,2 @@
 // This file is auto-generated at container startup
-window.RUNTIME_CONFIG = {
-  API_URL: "http://localhost:8000/api"
-};
+window.RUNTIME_CONFIG = undefined;


### PR DESCRIPTION
### Description

RUNTIME_CONFIG was overwritten during code migration. When it's not undefined, next_api_url substitution doesn't work as expected.

## Testing Instructions

Run app with next_api_url other than localhost. FE should call what is in next_api_url, not localhost:8000

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Screenshots (if applicable)

<!-- Drag and drop screenshots here -->

### Related Issue

Closes #[IssueNumber]
