### PR TITLE
Fix avatar bug

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -85,7 +85,8 @@
    },
    "settings": {
       "updateSuccess": "Benutzereinstellungen aktualisiert",
-      "updateError": "Beim Aktualisieren der Benutzereinstellungen ist ein Fehler aufgetreten"
+      "updateError": "Beim Aktualisieren der Benutzereinstellungen ist ein Fehler aufgetreten",
+      "nothingToUpload": "Es gibt nichts zum Hochladen"
    },
    "homePage": {
       "documentName": "Name",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -85,7 +85,8 @@
    },
    "settings": {
       "updateSuccess": "User settings updated successfully",
-      "updateError": "Something went wrong while updating user settings"
+      "updateError": "Something went wrong while updating user settings",
+      "nothingToUpload": "Nothing to upload"
    },
    "homePage": {
       "documentName": "Document name",

--- a/frontend/src/app/(ts)/userSettings/page.tsx
+++ b/frontend/src/app/(ts)/userSettings/page.tsx
@@ -38,11 +38,16 @@ export default function UserSettings() {
 
    const handleSubmit = async () => {
       // TODO when appropriate add other fields, updateUser instead of uploadAvatar
+      if (!file) {
+         toast.info(settingsTranslations("nothingToUpload"));
+         return;
+      }
       try {
          const formData = new FormData();
          formData.append("file", file, file.name);
          await uploadAvatar(formData);
          toast.success(settingsTranslations("updateSuccess"));
+         setFile(null);
       } catch (err) {
          console.error("Updating user failed: ", err);
          toast.error(settingsTranslations("updateError"));

--- a/frontend/src/contexts/UserContext.tsx
+++ b/frontend/src/contexts/UserContext.tsx
@@ -129,6 +129,11 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
       try {
          const response = await downloadAvatar();
 
+         if (!response) {
+            // No avatar uploaded yet — expected for new users
+            return null;
+         }
+
          if (response.ok) {
             const blob = await response.blob();
             const avatar = URL.createObjectURL(blob);

--- a/frontend/src/lib/services.ts
+++ b/frontend/src/lib/services.ts
@@ -612,18 +612,42 @@ export const confirmRegistration = async (
 };
 
 export const uploadAvatar = async (formData: FormData) => {
-   const res = await fetch(`${USERS_ENDPOINT}/avatar`, {
-      method: "POST",
-      credentials: "include",
-      body: formData
-   });
-   return res.json();
+   try {
+      const res = await fetch(`${USERS_ENDPOINT}/avatar`, {
+         method: "POST",
+         credentials: "include",
+         body: formData
+      });
+
+      if (!res.ok) {
+         throw new Error("Failed to upload avatar");
+      }
+      return res.json();
+   } catch (error) {
+      console.error("Error uploading avatar:", error);
+      throw error;
+   }
 };
 
 export const downloadAvatar = async () => {
-   const res = await fetch(`${USERS_ENDPOINT}/avatar`, {
-      method: "GET",
-      credentials: "include"
-   });
-   return res;
+   try {
+      const res = await fetch(`${USERS_ENDPOINT}/avatar`, {
+         method: "GET",
+         credentials: "include"
+      });
+
+      if (res.status === 404) {
+         // Avatar not found is expected for new users — return null
+         return null;
+      }
+
+      if (!res.ok) {
+         throw new Error("Failed to download avatar");
+      }
+
+      return res;
+   } catch (error) {
+      console.error("Error downloading avatar:", error);
+      throw error;
+   }
 };


### PR DESCRIPTION
### Description

- after first login when avatar is not uploaded yet for user, user no longer sees 404 error
- when user uploads avatar he gets success toast
- when user repeatedly clicks "Save settings" button although there is nothing to upload he gets info toast and no request is send to backend

## Testing Instructions

- create new user and login with this user
- after login you should not see 404 error pop on the screen (it is still present in console though)
- try to upload new avatar
- try to click "Save settings" button multiple times with no change to avatar and you should get info toast, no request is send to backend

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Screenshots (if applicable)

<!-- Drag and drop screenshots here -->

### Related Issue

Closes #88 
