### PR TITLE
101 Correct redirect of logged in user

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,20 +3,28 @@
 import { useEffect } from "react";
 
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 
 import { useUser } from "@/contexts/UserContext";
 
 export default function Root() {
    const router = useRouter();
-   const { isLoggedIn } = useUser();
+   const { isLoggedIn, loading } = useUser();
+   const generalTranslations = useTranslations("general");
 
    useEffect(() => {
-      if (isLoggedIn) {
-         router.push("/home");
-      } else {
-         router.push("/login");
+      if (!loading) {
+         if (isLoggedIn) {
+            router.push("/home");
+         } else {
+            router.push("/login");
+         }
       }
-   }, [router]);
+   }, [isLoggedIn, loading, router]);
+
+   if (loading) {
+      return <p>{generalTranslations("loading")}</p>;
+   }
 
    return null;
 }


### PR DESCRIPTION
### Description

- adjusted logic so that logged in user when entering root url is redirected to /home not /login

## Testing Instructions

- log in
- try to type localhost:3000 in url
- redirect should be to the /home not /login now

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix

### Screenshots (if applicable)

<!-- Drag and drop screenshots here -->

### Related Issue

Closes #101 
