### PR TITLE
added option to resend account confirmation email

### DIFF
--- a/backend/src/clients/db/users.ts
+++ b/backend/src/clients/db/users.ts
@@ -67,7 +67,7 @@ export const findUserByEmailDb = async (email: string) => {
 export const findUserByTokenDb = async (token: string) => {
   try {
     const user = await db<UserDb>("users")
-      .select("id")
+      .select("id", "email", "username", "status")
       .where({ user_token: token })
       .first();
     return user;
@@ -101,7 +101,9 @@ export const getTotalRecentlyAddedUsersDb = async (): Promise<number> => {
 
 export const activateUserDb = async (userId: number): Promise<void> => {
   try {
-    await db("users").where({ id: userId }).update({ status: USER_STATUS.active });
+    await db("users")
+      .where({ id: userId })
+      .update({ status: USER_STATUS.active });
   } catch (error) {
     logger.error("Error activating user:", error);
   }
@@ -118,7 +120,10 @@ export const storeAvatarCidDb = async (email: string, cid: string) => {
   }
 };
 
-export const updateUserPassword = async (userId: number, passwordHash: string) => {
+export const updateUserPassword = async (
+  userId: number,
+  passwordHash: string
+) => {
   try {
     await db<UserDb>("users")
       .update({ password_hash: passwordHash })
@@ -127,4 +132,15 @@ export const updateUserPassword = async (userId: number, passwordHash: string) =
     logger.error("Error updating user", error);
     throw new Error("Error updating user");
   }
-}
+};
+
+export const updateUserToken = async (userId: number, token: string) => {
+  try {
+    await db<UserDb>("users")
+      .update({ user_token: token })
+      .where({ id: userId });
+  } catch (error) {
+    logger.error("Error updating user", error);
+    throw new Error("Error updating user");
+  }
+};

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -26,7 +26,10 @@ import {
 import { authenticateCookie } from "../middlewares/authenticate";
 import validate from "../middlewares/validate";
 import { JwtPayload } from "../types/interfaces";
-import { USER_STATUS } from "../utility/constants";
+import {
+  CONFIRMATION_EMAIL_EXPIRATION,
+  USER_STATUS,
+} from "../utility/constants";
 import { AuthenticatedRequest } from "../types";
 import { IpfsClient } from "../clients/ipfs-client";
 import { UploadedFile } from "express-fileupload";
@@ -56,7 +59,7 @@ router.post(
     const passwordHash = await hashPassword(password);
     const token = config.registerUsersAsInactive
       ? jwt.sign({ email: email }, Buffer.from(config.jwt.secret), {
-          expiresIn: 1200, // 20 minutes
+          expiresIn: CONFIRMATION_EMAIL_EXPIRATION, // 20 minutes
         })
       : "";
     try {
@@ -279,7 +282,7 @@ router.post(
               { email: user.email },
               Buffer.from(config.jwt.secret),
               {
-                expiresIn: 1200, // 20 minutes
+                expiresIn: CONFIRMATION_EMAIL_EXPIRATION, // 20 minutes
               }
             );
             await updateUserToken(user.id, newToken);

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -13,6 +13,7 @@ import {
   getTotalUsersDb,
   storeAvatarCidDb,
   updateUserPassword,
+  updateUserToken,
 } from "../clients/db";
 import { config } from "../config/config";
 import logger from "../config/winston";
@@ -53,9 +54,11 @@ router.post(
     const { registerUsersAsInactive } = config;
 
     const passwordHash = await hashPassword(password);
-    const token = jwt.sign({ email: email }, Buffer.from(config.jwt.secret), {
-      expiresIn: 1200, // 20 minutes
-    });
+    const token = config.registerUsersAsInactive
+      ? jwt.sign({ email: email }, Buffer.from(config.jwt.secret), {
+          expiresIn: 1200, // 20 minutes
+        })
+      : "";
     try {
       const result = await createUserDb(
         name,
@@ -85,13 +88,13 @@ router.post(
           footer: registrationConfirmation[lang].footer,
         };
         const htmlTemplateToSend = template(replacements);
-        logger.info("Sending email done");
+        logger.info("Sending email");
         await sendEmail(
           email,
           registrationConfirmation[lang].subject,
           htmlTemplateToSend
         );
-        logger.info("Sending email done");
+        logger.info("Email sent");
         res.json({
           status: "success",
           message: "email sent",
@@ -237,16 +240,23 @@ router.get(
   }
 );
 
-router.get(
+router.post(
   "/confirm-registration",
-  validate([query("token").isString().notEmpty()]),
+  validate([
+    query("token").isString().notEmpty(),
+    body("confirmationLink").isString(),
+    body("lang").isString(),
+  ]),
   async (req: Request, res: Response) => {
     const token = req.query.token as string;
-    jwt.verify(token, Buffer.from(config.jwt.secret)) as jwt.JwtPayload;
+    const { lang, confirmationLink } = req.body;
+
     try {
+      jwt.verify(token, Buffer.from(config.jwt.secret)) as jwt.JwtPayload;
       const user = await findUserByTokenDb(token);
       if (user) {
         await activateUserDb(user.id);
+        await updateUserToken(user.id, "");
         res.status(200).json({
           status: "success",
           message: "User activated successfully",
@@ -259,10 +269,58 @@ router.get(
       }
     } catch (error: any) {
       logger.error(error);
-      if (
-        error.message === "jwt expired" ||
-        error.message === "invalid signature"
-      ) {
+      if (error.message === "jwt expired") {
+        try {
+          const user = await findUserByTokenDb(token);
+          if (user) {
+            const newToken = jwt.sign(
+              { email: user.email },
+              Buffer.from(config.jwt.secret),
+              {
+                expiresIn: 1200, // 20 minutes
+              }
+            );
+            await updateUserToken(user.id, newToken);
+            const filePath = path.join(
+              process.cwd(),
+              "src/mailing/templates/registrationConfirmation.html"
+            );
+            const source = fs.readFileSync(filePath, "utf-8");
+            const template = compile(source);
+            const replacements = {
+              lang: lang,
+              header: registrationConfirmation[lang].header,
+              user: user.username,
+              text: registrationConfirmation[lang].text,
+              confirmRegistrationUrl: `${confirmationLink}?token=${newToken}`,
+              confirmRegistrationTitle: registrationConfirmation[lang].link,
+              footer: registrationConfirmation[lang].footer,
+            };
+            const htmlTemplateToSend = template(replacements);
+            logger.info("Sending email");
+            await sendEmail(
+              user.email,
+              registrationConfirmation[lang].subject,
+              htmlTemplateToSend
+            );
+            logger.info("New confirmation email sent");
+            return res.status(400).json({
+              status: "error",
+              message: "expired token",
+            });
+          }
+          return res.status(500).json({
+            status: "failure",
+            message: "Unknown error occurred",
+          });
+        } catch (err) {
+          logger.error(err);
+          return res.status(500).json({
+            status: "failure",
+            message: "Unknown error occurred",
+          });
+        }
+      } else if (error.message === "invalid signature") {
         res.status(400).json({
           status: "error",
           message: "invalid token",

--- a/backend/src/utility/constants.ts
+++ b/backend/src/utility/constants.ts
@@ -7,3 +7,5 @@ export const USER_PERMISSION_STATUS = {
   active: "active",
   inactive: "inactive",
 };
+
+export const CONFIRMATION_EMAIL_EXPIRATION = 1200; // seconds

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -58,6 +58,7 @@
       "text": "Klick bitte auf den Button unten, um deine Registrierung abzuschließen",
       "confirmError": "Es ist ein Fehler aufgetreten. Versuch's bitte nochmal.",
       "confirmErrorToken": "Fehler bei der Bestätigung: Der Link ist ungültig",
+      "confirmErrorTokenExpired": "Fehler bei der Bestätigung: Token ist abgelaufen, neue Bestätigungs-E-Mail wurde gesendet",
       "confirmSuccess": "Geschafft! Deine Registrierung ist abgeschlossen. Du kannst dich jetzt anmelden."
    },
    "forgotPassword": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -58,6 +58,7 @@
       "text": "Please, click the button below to finish your registration",
       "confirmError": "An error occurred, please try again",
       "confirmErrorToken": "Account confirmation error: token is invalid",
+      "confirmErrorTokenExpired": "Account confirmation error: token has expired, new confirmation email has been sent",
       "confirmSuccess": "Success! Account registration finished, you can proceed to login page"
    },
    "forgotPassword": {

--- a/frontend/src/app/confirm/page.tsx
+++ b/frontend/src/app/confirm/page.tsx
@@ -16,6 +16,7 @@ import {
    CardHeader,
    CardTitle
 } from "@/components/ui/card";
+import { getUserLocale } from "@/i18n/service";
 import { confirmRegistration } from "@/lib/services";
 
 export default function ConfirmRegistration({}: React.ComponentPropsWithoutRef<"div">) {
@@ -23,11 +24,18 @@ export default function ConfirmRegistration({}: React.ComponentPropsWithoutRef<"
    const token = useSearchParams().get("token");
 
    const onConfirmClick = async () => {
-      const response = await confirmRegistration(token);
+      const locale = await getUserLocale();
+      const data = {
+         lang: locale,
+         confirmationLink: `${window.location.origin}/confirm`
+      };
+      const response = await confirmRegistration(token, data);
       if (response.status === "success") {
          toast.success(translations("confirmSuccess"));
       } else if (response.message === "invalid token") {
          toast.error(translations("confirmErrorToken"));
+      } else if (response.message === "expired token") {
+         toast.error(translations("confirmErrorTokenExpired"));
       } else {
          toast.error(translations("confirmError"));
       }

--- a/frontend/src/lib/services.ts
+++ b/frontend/src/lib/services.ts
@@ -603,22 +603,28 @@ export const logout = async (): Promise<{
 };
 
 export const confirmRegistration = async (
-   token: string
+   token: string,
+   formData: {
+      lang: string;
+      confirmationLink: string;
+   }
 ): Promise<{
    status: string;
    message: string;
 }> => {
    try {
-      const response = await fetch(
-         `${USERS_ENDPOINT}/confirm-registration?token=${token}`,
-         {
-            method: "GET"
-         }
-      );
-
-      if (!response.ok) {
-         throw new Error("Failed to confirm registration");
-      }
+      const url = `${USERS_ENDPOINT}/confirm-registration?token=${token}`;
+      const options: RequestInit = {
+         method: "POST",
+         headers: {
+            "Content-Type": "application/json"
+         },
+         body: JSON.stringify({
+            lang: formData.lang,
+            confirmationLink: formData.confirmationLink
+         })
+      };
+      const response = await fetch(url, options);
 
       return await response.json();
    } catch (error) {


### PR DESCRIPTION
### Description

* added option to resend account activation email

## Testing Instructions

* run app with `REGISTER_USERS_AS_INACTIVE=true` env var
* in `backend/src/routes/users.ts` change line 59 value to 1 so the token quickly expires
* run mailhog `docker run -d -p 8025:8025 -p 1025:1025 -e MH_HOSTNAME='mailhog.local' mailhog/mailhog`
* open localhost:8025
* register new account in Truspace and click the link in received email
* click the button on confirmation page and you should see error that token expired and you should receive new activation email
* open the link in it, click the button and now account should be activated and you can log into the app

### Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Screenshots (if applicable)

<!-- Drag and drop screenshots here -->

### Related Issue

Closes #109 
