### PR TITLE
#137 Redirect to login after confirm account

### DIFF
--- a/frontend/src/app/confirm/page.tsx
+++ b/frontend/src/app/confirm/page.tsx
@@ -4,7 +4,7 @@ import { toast } from "react-toastify";
 
 import Image from "next/image";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 
 import { LanguageToggle } from "@/components/LanguageToggle";
@@ -22,6 +22,7 @@ import { confirmRegistration } from "@/lib/services";
 export default function ConfirmRegistration({}: React.ComponentPropsWithoutRef<"div">) {
    const translations = useTranslations("confirmRegistration");
    const token = useSearchParams().get("token");
+   const router = useRouter();
 
    const onConfirmClick = async () => {
       const locale = await getUserLocale();
@@ -32,6 +33,7 @@ export default function ConfirmRegistration({}: React.ComponentPropsWithoutRef<"
       const response = await confirmRegistration(token, data);
       if (response.status === "success") {
          toast.success(translations("confirmSuccess"));
+         router.push("/login");
       } else if (response.message === "invalid token") {
          toast.error(translations("confirmErrorToken"));
       } else if (response.message === "expired token") {


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->

## Testing Instructions

- make sure you have SMTP server up and running
- set REGISTER_USERS_AS_INACTIVE=true
- try register new user
- click on "Confirm registration" link in the email you received to confirm your registration
- click on "Confirm account registration" button on the screen you will be redirected to
- you should be redirected to login page if the process is a success

### Type of Change

Please delete options that are not relevant.

- [x] ✨ New feature

### Screenshots (if applicable)

<!-- Drag and drop screenshots here -->

### Related Issue

Closes #137 
