### PR TITLE
feat: add button that copies the perspective to the ask AI dialog

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -326,7 +326,8 @@
       "promptTitlePlaceHolder": "Gib den Titel Deines Prompts ein",
       "promptBodyPlaceholder": "Gib Deinen Prompt ein",
       "savePrompt": "Prompt speichern",
-      "saveCustomPromptHint": "Das Speichern von Prompts funktioniert noch nicht"
+      "saveCustomPromptHint": "Das Speichern von Prompts funktioniert noch nicht",
+      "generateNewPerspectiveFromPrevious": "Mit KI anpassen"
    },
    "documentEditable": {
       "cancel": "Abbrechen",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -326,7 +326,8 @@
       "promptTitlePlaceHolder": "Enter a title of your prompt",
       "promptBodyPlaceholder": "Enter your prompt",
       "savePrompt": "Save prompt",
-      "saveCustomPromptHint": "Saving prompts doesn't work"
+      "saveCustomPromptHint": "Saving prompts doesn't work",
+      "generateNewPerspectiveFromPrevious": "Adjust with AI"
    },
    "documentEditable": {
       "cancel": "Cancel",

--- a/frontend/src/app/(ts)/workspace/[workspaceId]/document/[documentId]/DocumentPerspectives.tsx
+++ b/frontend/src/app/(ts)/workspace/[workspaceId]/document/[documentId]/DocumentPerspectives.tsx
@@ -16,7 +16,6 @@ import {
 import { marked } from "marked";
 import TurndownService from "turndown";
 
-import { formatDate } from "@/lib/formatDate";
 import Editor from "@/components/tiptap-editor/Editor";
 import { Button } from "@/components/ui/button";
 import {
@@ -42,6 +41,7 @@ import {
    TooltipProvider,
    TooltipTrigger
 } from "@/components/ui/tooltip";
+import { formatDate } from "@/lib/formatDate";
 import {
    createPerspective,
    customPerspective,
@@ -476,16 +476,30 @@ export default function DocumentPerspectives({ cid, docId, workspaceOrigin }) {
                         <Plus /> {t("addYourPerspective")}
                      </Button>
 
-                     <Button
-                        ref={promptButtonRef}
-                        variant="outline"
-                        onClick={() => {
-                           setCustomPromptDialogOpen(true);
-                        }}
-                        className={`mr-4 ${isPromptWrapped ? "mt-2" : ""}`}
-                     >
-                        <MessageCircleQuestion /> {t("askCustomPrompt")}
-                     </Button>
+                     <div className={isWrapped ? "mt-2" : ""}>
+                        <Button
+                           ref={promptButtonRef}
+                           variant="outline"
+                           onClick={() => {
+                              setCustomPromptDialogOpen(true);
+                           }}
+                           className={`mr-4 ${isPromptWrapped ? "mt-2" : ""}`}
+                        >
+                           <MessageCircleQuestion /> {t("askCustomPrompt")}
+                        </Button>
+                        <Button
+                           ref={promptButtonRef}
+                           variant="outline"
+                           onClick={() => {
+                              setPromptText(currentPerspective?.text || "");
+                              setCustomPromptDialogOpen(true);
+                           }}
+                           className={`mr-4 ${isPromptWrapped ? "mt-2" : ""}`}
+                        >
+                           <MessageCircleQuestion />{" "}
+                           {t("generateNewPerspectiveFromPrevious")}
+                        </Button>
+                     </div>
                      <div ref={selectRef} className={isWrapped ? "mt-2" : ""}>
                         <Select
                            value={selectedPerspective}

--- a/frontend/src/app/(ts)/workspace/[workspaceId]/document/[documentId]/DocumentPerspectives.tsx
+++ b/frontend/src/app/(ts)/workspace/[workspaceId]/document/[documentId]/DocumentPerspectives.tsx
@@ -476,7 +476,7 @@ export default function DocumentPerspectives({ cid, docId, workspaceOrigin }) {
                         <Plus /> {t("addYourPerspective")}
                      </Button>
 
-                     <div className={isWrapped ? "mt-2" : ""}>
+                     <div>
                         <Button
                            ref={promptButtonRef}
                            variant="outline"


### PR DESCRIPTION
### Description

This PR adds a small button on the perspective tab which copies the perspective into the "ask AI" dialog so it doesnt need to be manual. 

## Testing Instructions

Go to a workspace document
Under Perspectives wait for a perspective to be generated.
Then choose a perspective and click "adjust with AI"

Expected outcome: 

A dialog opens with the prompt title empty but the prompt being the perspective.

### Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Screenshots (if applicable)

<img width="751" height="368" alt="Screenshot 2025-07-16 154610" src="https://github.com/user-attachments/assets/f48e45f1-b5cb-4de3-a409-3eb8d8c8e1d3" />

### Related Issue

Closes #7 
