### PR TITLE
Handle "undefined" string in chats

### DIFF
--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -1,6 +1,8 @@
-import { formatDate } from "@/lib/formatDate";
-import { ExternalLink } from "lucide-react";
 import { useTranslations } from "next-intl";
+
+import { ExternalLink } from "lucide-react";
+
+import { formatDate } from "@/lib/formatDate";
 
 import InfoLabel from "./InfoLabel";
 
@@ -38,7 +40,9 @@ export default function ChatMessage({
             </div>
             <span className="text-sm font-normal text-gray-500 dark:text-gray-400">
                {translations("messageForVersion")} {version}
-               {versionTagName ? `, ${versionTagName}` : ""}
+               {versionTagName && versionTagName !== "undefined"
+                  ? `, ${versionTagName}`
+                  : ""}
             </span>
          </div>
       </div>


### PR DESCRIPTION
### Description

Undefined tag version is returned as a string "undefined" from backend. There is a check for falsy types, "undefined" however, is a valid string.

## Testing Instructions

Upload a document or a version without a tag. Create one or more chat messages. Chats should not display "undefined" tag. (Picture in issue description #149 ) 

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Screenshots (if applicable)

<!-- Drag and drop screenshots here -->

### Related Issue

Closes #149 
