### PR TITLE
148 New dashboard screen + old dashboard content to home screen

### DIFF
--- a/backend/src/clients/ipfs-client/index.ts
+++ b/backend/src/clients/ipfs-client/index.ts
@@ -556,6 +556,20 @@ export class IpfsClient implements IClient {
     return result;
   }
 
+  async getAllMessages(): Promise<ChatMessage[]> {
+    const res = await this.#pinSvcAxios.get(
+      `/pins?limit=1000&meta={"type":"chat"}`
+    );
+
+    const pins: PinningResponse = res.data;
+    const result = pins.results
+      .map((el) => this.#transformPinToChatMessage(el.pin))
+      .sort((a: ChatMessage, b: ChatMessage) => {
+        return Number(a.meta.timestamp) - Number(b.meta.timestamp);
+      });
+    return result;
+  }
+
   async createPerspective(_perspective: PerspectiveRequest): Promise<string> {
     try {
       const json = JSON.stringify(_perspective, null);

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -60,10 +60,14 @@ router.get("/recent", async (req: AuthenticatedRequest, res: Response) => {
     (ws) => allowedWs.includes(ws.uuid) || ws.meta.is_public
   );
   const result = await client.getAllMessages();
-  const filteredMessages = result.filter((message) => {
-    const workspaceOrigin = message.meta.workspaceOrigin;
-    return allAllowedWs.some((ws) => ws.uuid === workspaceOrigin);
-  });
+  const filteredMessages = result
+    .filter((message) => {
+      const workspaceOrigin = message.meta.workspaceOrigin;
+      return allAllowedWs.some((ws) => ws.uuid === workspaceOrigin);
+    })
+    .sort((a, b) => {
+      return Number(b.meta.timestamp) - Number(a.meta.timestamp);
+    });
   // return only the most recent 10 messages
   res.json(filteredMessages.splice(0, 10));
 });

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -8,6 +8,7 @@ import { AuthenticatedRequest } from "../types";
 import { ChatMessageRequest } from "../types/interfaces";
 import { getUserSettingsByUiid } from "../utility/user";
 import { sendNotification } from "../mailing/notifications";
+import { findPermissionsByEmailDb } from "../clients/db";
 
 const router = express.Router();
 const client = new IpfsClient();
@@ -48,6 +49,23 @@ router.get("/export/:docId", async (req: Request, res: Response) => {
   });
 
   doc.end();
+});
+
+router.get("/recent", async (req: AuthenticatedRequest, res: Response) => {
+  const allWorkspaces = await new IpfsClient().getAllWorkspaces();
+  const allowedWs = (
+    await findPermissionsByEmailDb(req.user?.email as string)
+  ).map((p) => p.workspace_id);
+  const allAllowedWs = allWorkspaces.filter(
+    (ws) => allowedWs.includes(ws.uuid) || ws.meta.is_public
+  );
+  const result = await client.getAllMessages();
+  const filteredMessages = result.filter((message) => {
+    const workspaceOrigin = message.meta.workspaceOrigin;
+    return allAllowedWs.some((ws) => ws.uuid === workspaceOrigin);
+  });
+  // return only the most recent 10 messages
+  res.json(filteredMessages.splice(0, 10));
 });
 
 /* GET chat messages by document ID */

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -195,6 +195,7 @@
       "noDocumentAvailable": "Kein Dokument verfügbar",
       "noChatMessageAvailable": "Keine Chat-Nachricht verfügbar",
       "recentlyAddedWorkspace": "Kürzlich hinzugefügte Arbeitsbereiche",
+      "noRecentWorkspaceAvailable": "Keine kürzlich hinzugefügten Arbeitsbereiche verfügbar",
       "documentActions": "Dokumentaktionen",
       "workspaceActions": "Arbeitsbereichsaktionen"
    },

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -181,7 +181,22 @@
       "chooseFiles": "Dateien auswählen",
       "fileSelected": "Datei ausgewählt",
       "filesSelected": "Dateien ausgewählt",
-      "privateWorkspace": "Der Arbeitsbereich ist privat"
+      "privateWorkspace": "Der Arbeitsbereich ist privat",
+      "lastEditedDocument": "Zuletzt bearbeitetes Dokument",
+      "lastChatMessage": "Letzte Chat-Nachricht",
+      "editedOn": "Bearbeitet am",
+      "editedBy": "Bearbeitet von",
+      "sentOn": "Gesendet am",
+      "addedBy": "Hinzugefügt von",
+      "addedOn": "Hinzugefügt am",
+      "document": "Dokument",
+      "unknownCreator": "Unbekannte/r AutorIn",
+      "unknownDocument": "Unbekanntes Dokument",
+      "noDocumentAvailable": "Kein Dokument verfügbar",
+      "noChatMessageAvailable": "Keine Chat-Nachricht verfügbar",
+      "recentlyAddedWorkspace": "Kürzlich hinzugefügte Arbeitsbereiche",
+      "documentActions": "Dokumentaktionen",
+      "workspaceActions": "Arbeitsbereichsaktionen"
    },
    "documentPreview": {
       "preview": "Vorschau",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -195,6 +195,7 @@
       "noDocumentAvailable": "No document available",
       "noChatMessageAvailable": "No chat message available",
       "recentlyAddedWorkspace": "Recently added workspace",
+      "noRecentWorkspaceAvailable": "No recent workspace available",
       "documentActions": "Document actions",
       "workspaceActions": "Workspace actions"
    },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -181,7 +181,22 @@
       "chooseFiles": "Choose Files",
       "fileSelected": "file selected",
       "filesSelected": "files selected",
-      "privateWorkspace": "Workspace is private"
+      "privateWorkspace": "Workspace is private",
+      "lastEditedDocument": "Last edited document",
+      "lastChatMessage": "Last chat message",
+      "editedOn": "Edited on",
+      "editedBy": "Edited by",
+      "sentOn": "Sent on",
+      "addedBy": "Added by",
+      "addedOn": "Added on",
+      "document": "Document",
+      "unknwownCreator": "Unknown author",
+      "unknownDocument": "Unknown document",
+      "noDocumentAvailable": "No document available",
+      "noChatMessageAvailable": "No chat message available",
+      "recentlyAddedWorkspace": "Recently added workspace",
+      "documentActions": "Document actions",
+      "workspaceActions": "Workspace actions"
    },
    "documentPreview": {
       "preview": "Preview",

--- a/frontend/src/app/(ts)/dashboard/page.tsx
+++ b/frontend/src/app/(ts)/dashboard/page.tsx
@@ -1,5 +1,283 @@
-import AppFeatures from "@/components/AppFeatures";
+"use client";
+import { useEffect, useState } from "react";
 
-export default async function Dashboard() {
-   return <AppFeatures />;
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+
+import { FileText, Folder, MessageCircle } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useDocuments } from "@/contexts/DocumentsContext";
+import { useWorkspaceContext } from "@/contexts/WorkspaceContext";
+import { ChatMessage } from "@/interfaces";
+import { useRecentChats } from "@/lib/services";
+
+export default function Dashboard() {
+   const { allDocuments, fetchAllDocuments } = useDocuments();
+   const { availableWorkspaces } = useWorkspaceContext();
+   const router = useRouter();
+   const [err, setErr] = useState(null);
+   const [loading, setLoading] = useState(true);
+   const { chats, error, isLoading } = useRecentChats();
+   const generalTranslations = useTranslations("general");
+   const homeTranslations = useTranslations("homePage");
+
+   useEffect(() => {
+      const loadAllDocuments = async () => {
+         try {
+            fetchAllDocuments();
+         } catch (err) {
+            setErr(err.message);
+         } finally {
+            setLoading(false);
+         }
+      };
+      loadAllDocuments();
+   }, []);
+
+   const lastChatMessage: ChatMessage = chats?.sort(
+      (
+         a: { meta: { timestamp: string } },
+         b: { meta: { timestamp: string } }
+      ) =>
+         new Date(b.meta?.timestamp).getTime() -
+         new Date(a.meta?.timestamp).getTime()
+   )[0];
+
+   const lastEditedDocument = allDocuments.sort(
+      (a, b) =>
+         new Date(b.meta?.timestamp).getTime() -
+         new Date(a.meta?.timestamp).getTime()
+   )[0];
+
+   const lastChatMessageDocName = allDocuments.find(
+      (doc) => doc.docId === lastChatMessage?.meta?.docId
+   )?.meta?.filename;
+
+   const recentlyAddedWorkspace = availableWorkspaces?.sort(
+      (a, b) =>
+         new Date(b.meta?.created_at).getTime() -
+         new Date(a.meta?.created_at).getTime()
+   )[0];
+
+   const cardBaseStyles = `group relative overflow-hidden bg-white dark:bg-gray-800 hover:scale-[1.02] hover:-translate-y-1 hover:ring-2 hover:ring-blue-400 dark:hover:ring-blue-600
+      transition-all duration-300 ease-out cursor-pointer before:absolute before:inset-0 before:bg-gradient-to-br before:from-blue-100 before:to-transparent dark:before:from-blue-900/20
+      before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-300`;
+
+   const iconWrapStyles =
+      "transition-transform duration-300 group-hover:scale-110 group-hover:text-blue-600";
+
+   return (
+      <div className="space-y-10">
+         <div className="space-y-4">
+            <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-200">
+               {homeTranslations("documentActions")}
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+               <Card
+                  className={cardBaseStyles}
+                  onClick={() =>
+                     router.push(
+                        `/workspace/${lastEditedDocument?.meta?.workspaceOrigin}/document/${lastEditedDocument?.docId}`
+                     )
+                  }
+               >
+                  <CardHeader className="flex flex-row items-center gap-2 relative z-10">
+                     <FileText className={`text-blue-500 ${iconWrapStyles}`} />
+                     <CardTitle>
+                        {homeTranslations("lastEditedDocument")}
+                     </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-2 space-y-2 relative z-10">
+                     {loading ? (
+                        <p className="text-muted-foreground">
+                           {generalTranslations("loading")}
+                        </p>
+                     ) : err ? (
+                        <p className="text-red-500">{err}</p>
+                     ) : lastEditedDocument ? (
+                        <>
+                           <div className="flex items-baseline gap-2">
+                              <span className="text-sm text-muted-foreground">
+                                 {homeTranslations("document")}:
+                              </span>
+                              <span className="text-base font-semibold truncate">
+                                 {lastEditedDocument.meta.filename ||
+                                    homeTranslations("unknownDocument")}
+                              </span>
+                           </div>
+                           <div className="flex items-baseline gap-2">
+                              <span className="text-sm text-muted-foreground">
+                                 {homeTranslations("editedBy")}:
+                              </span>
+                              <span className="text-base font-semibold truncate">
+                                 {lastEditedDocument.meta.creator ||
+                                    homeTranslations("unknownCreator")}
+                              </span>
+                           </div>
+                           <div className="flex items-baseline gap-2">
+                              <span className="text-sm text-muted-foreground">
+                                 {homeTranslations("editedOn")}:
+                              </span>
+                              <span className="text-base font-semibold truncate">
+                                 {new Date(
+                                    Number(lastEditedDocument.meta.timestamp)
+                                 ).toLocaleString("en-GB", {
+                                    day: "2-digit",
+                                    month: "2-digit",
+                                    year: "numeric",
+                                    hour: "2-digit",
+                                    minute: "2-digit",
+                                    second: "2-digit",
+                                    hour12: false
+                                 })}
+                              </span>
+                           </div>
+                        </>
+                     ) : (
+                        <p className="text-muted-foreground">
+                           {homeTranslations("noDocumentAvailable")}
+                        </p>
+                     )}
+                  </CardContent>
+               </Card>
+               <Card
+                  className={cardBaseStyles}
+                  onClick={() =>
+                     router.push(
+                        `/workspace/${lastChatMessage?.meta?.workspaceOrigin}/document/${lastChatMessage?.meta?.docId}`
+                     )
+                  }
+               >
+                  <CardHeader className="flex flex-row items-center gap-2 relative z-10">
+                     <MessageCircle
+                        className={`text-blue-500 ${iconWrapStyles}`}
+                     />
+                     <CardTitle>
+                        {homeTranslations("lastChatMessage")}
+                     </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-2 space-y-2 relative z-10">
+                     {isLoading ? (
+                        <p className="text-muted-foreground">
+                           {generalTranslations("loading")}
+                        </p>
+                     ) : error ? (
+                        <p className="text-red-500">{error}</p>
+                     ) : lastChatMessage ? (
+                        <>
+                           <div className="flex items-baseline gap-2">
+                              <span className="text-sm text-muted-foreground">
+                                 {homeTranslations("document")}:
+                              </span>
+                              <span className="text-base font-semibold truncate">
+                                 {lastChatMessageDocName ||
+                                    homeTranslations("unknownDocument")}
+                              </span>
+                           </div>
+                           <div className="flex items-baseline gap-2">
+                              <span className="text-sm text-muted-foreground">
+                                 {homeTranslations("addedBy")}:
+                              </span>
+                              <span className="text-base font-semibold truncate">
+                                 {lastChatMessage.meta.creator ||
+                                    homeTranslations("unknownCreator")}
+                              </span>
+                           </div>
+                           <div className="flex items-baseline gap-2">
+                              <span className="text-sm text-muted-foreground">
+                                 {homeTranslations("sentOn")}:
+                              </span>
+                              <span className="text-base font-semibold truncate">
+                                 {new Date(
+                                    Number(lastChatMessage.meta.timestamp)
+                                 ).toLocaleString("en-GB", {
+                                    day: "2-digit",
+                                    month: "2-digit",
+                                    year: "numeric",
+                                    hour: "2-digit",
+                                    minute: "2-digit",
+                                    second: "2-digit",
+                                    hour12: false
+                                 })}
+                              </span>
+                           </div>
+                        </>
+                     ) : (
+                        <p className="text-muted-foreground">
+                           {homeTranslations("noChatMessageAvailable")}
+                        </p>
+                     )}
+                  </CardContent>
+               </Card>
+            </div>
+         </div>
+         <div className="space-y-4">
+            <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-200">
+               {homeTranslations("workspaceActions")}
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+               <Card
+                  className={cardBaseStyles}
+                  onClick={() =>
+                     router.push(
+                        `/workspace/${recentlyAddedWorkspace?.meta?.workspace_uuid}`
+                     )
+                  }
+               >
+                  <CardHeader className="flex flex-row items-center gap-2 relative z-10">
+                     <Folder className={`text-blue-500 ${iconWrapStyles}`} />
+                     <CardTitle>
+                        {homeTranslations("recentlyAddedWorkspace")}
+                     </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-2 space-y-2 relative z-10">
+                     {isLoading ? (
+                        <p className="text-muted-foreground">
+                           {generalTranslations("loading")}
+                        </p>
+                     ) : error ? (
+                        <p className="text-red-500">{error}</p>
+                     ) : recentlyAddedWorkspace ? (
+                        <>
+                           <div className="flex items-baseline gap-2">
+                              <span className="text-sm text-muted-foreground">
+                                 {generalTranslations("workspace")}:
+                              </span>
+                              <span className="text-base font-semibold truncate">
+                                 {recentlyAddedWorkspace.meta.name ||
+                                    homeTranslations("unknownDocument")}
+                              </span>
+                           </div>
+                           <div className="flex items-baseline gap-2">
+                              <span className="text-sm text-muted-foreground">
+                                 {homeTranslations("addedBy")}:
+                              </span>
+                              <span className="text-base font-semibold truncate">
+                                 {recentlyAddedWorkspace.meta.creator_name ||
+                                    homeTranslations("unknownCreator")}
+                              </span>
+                           </div>
+                           <div className="flex items-baseline gap-2">
+                              <span className="text-sm text-muted-foreground">
+                                 {homeTranslations("addedOn")}:
+                              </span>
+                              <span className="text-base font-semibold truncate">
+                                 {new Date(
+                                    recentlyAddedWorkspace.meta.created_at
+                                 ).toLocaleString()}
+                              </span>
+                           </div>
+                        </>
+                     ) : (
+                        <p className="text-muted-foreground">
+                           {homeTranslations("noChatMessageAvailable")}
+                        </p>
+                     )}
+                  </CardContent>
+               </Card>
+            </div>
+         </div>
+      </div>
+   );
 }

--- a/frontend/src/app/(ts)/dashboard/page.tsx
+++ b/frontend/src/app/(ts)/dashboard/page.tsx
@@ -232,13 +232,7 @@ export default function Dashboard() {
                      </CardTitle>
                   </CardHeader>
                   <CardContent className="pt-2 space-y-2 relative z-10">
-                     {isLoading ? (
-                        <p className="text-muted-foreground">
-                           {generalTranslations("loading")}
-                        </p>
-                     ) : error ? (
-                        <p className="text-red-500">{error}</p>
-                     ) : recentlyAddedWorkspace ? (
+                     {recentlyAddedWorkspace ? (
                         <>
                            <div className="flex items-baseline gap-2">
                               <span className="text-sm text-muted-foreground">
@@ -271,7 +265,7 @@ export default function Dashboard() {
                         </>
                      ) : (
                         <p className="text-muted-foreground">
-                           {homeTranslations("noChatMessageAvailable")}
+                           {homeTranslations("noRecentWorkspaceAvailable")}
                         </p>
                      )}
                   </CardContent>

--- a/frontend/src/app/(ts)/home/page.tsx
+++ b/frontend/src/app/(ts)/home/page.tsx
@@ -1,31 +1,5 @@
-"use client";
-import { useEffect } from "react";
-
-import { useParams, useRouter } from "next/navigation";
-
-import DocumentList from "@/components/DocumentList";
-import { useWorkspaceContext } from "@/contexts/WorkspaceContext";
+import AppFeatures from "@/components/AppFeatures";
 
 export default function Home() {
-   const { slug } = useParams();
-   const router = useRouter();
-   const { availableWorkspaces, workspacesLoading } = useWorkspaceContext();
-
-   useEffect(() => {
-      function checkWorkspaces() {
-         if (!workspacesLoading) {
-            if (availableWorkspaces.length === 0) {
-               router.push("/dashboard");
-            }
-         }
-      }
-
-      checkWorkspaces();
-   }, [router, availableWorkspaces, workspacesLoading]);
-
-   return (
-      <div>
-         <DocumentList workspaceId={slug} />
-      </div>
-   );
+   return <AppFeatures />;
 }

--- a/frontend/src/contexts/DocumentsContext.tsx
+++ b/frontend/src/contexts/DocumentsContext.tsx
@@ -11,13 +11,19 @@ import {
 import { useTranslations } from "next-intl";
 
 import { Document, DocumentWithVersions } from "@/interfaces";
-import { loadDocumentDetail, loadDocuments } from "@/lib/services";
+import {
+   loadAllDocuments,
+   loadDocumentDetail,
+   loadDocuments
+} from "@/lib/services";
 
 interface DocumentsContextType {
+   allDocuments: Document[];
    documents: Document[];
    document: DocumentWithVersions | null;
    setDocuments: (documents: Document[]) => void;
    fetchDocuments: (workspaceId: string) => void;
+   fetchAllDocuments: () => void;
    fetchDocumentDetails: (documentID: string) => void;
    refreshUntilVersionFound: (
       docId: string,
@@ -26,10 +32,12 @@ interface DocumentsContextType {
 }
 
 export const DocumentsContext = createContext<DocumentsContextType>({
+   allDocuments: [],
    documents: [],
    document: null,
    setDocuments: () => null,
    fetchDocuments: () => null,
+   fetchAllDocuments: () => null,
    fetchDocumentDetails: () => null,
    refreshUntilVersionFound: () => null
 });
@@ -43,9 +51,15 @@ export const useDocuments = () => {
 };
 
 export const DocumentsProvider = ({ children }: { children: ReactNode }) => {
+   const [allDocuments, setAllDocuments] = useState<Document[]>([]);
    const [documents, setDocuments] = useState<Document[]>([]);
    const [document, setDocument] = useState<DocumentWithVersions>(null);
    const translations = useTranslations("homePage");
+
+   const fetchAllDocuments = async () => {
+      const data = await loadAllDocuments(translations("failedToFetch"));
+      setAllDocuments(data);
+   };
 
    const fetchDocuments = async (workspaceId) => {
       const data = await loadDocuments(
@@ -118,10 +132,12 @@ export const DocumentsProvider = ({ children }: { children: ReactNode }) => {
    return (
       <DocumentsContext.Provider
          value={{
+            allDocuments,
             document,
             documents,
             setDocuments,
             fetchDocuments,
+            fetchAllDocuments,
             fetchDocumentDetails,
             refreshUntilVersionFound
          }}

--- a/frontend/src/interfaces/index.ts
+++ b/frontend/src/interfaces/index.ts
@@ -72,6 +72,7 @@ interface ChatMessageMeta {
    perspectiveType: string;
    cid: string;
    docId: string;
+   workspaceOrigin: string;
    timestamp: string;
    creator: string;
    creatorUiid: string;

--- a/frontend/src/lib/services.ts
+++ b/frontend/src/lib/services.ts
@@ -25,6 +25,24 @@ const LANGUAGE_ENDPOINT = `${API_URL}/language`;
 
 // Documents api
 
+export const loadAllDocuments = async (errorText) => {
+   const url = DOCUMENTS_ENDPOINT;
+   const options: RequestInit = {
+      method: "GET",
+      credentials: "include"
+   };
+   const response = await fetch(url, options);
+   if (!response.ok) {
+      if (response.status === 401) {
+         throw new Error("unauthorized");
+      } else {
+         throw new Error(errorText);
+      }
+   }
+   const data = await response.json();
+   return data;
+};
+
 export const loadDocuments = async (workspaceId, errorText) => {
    const query = workspaceId ? `?workspace=${workspaceId}` : "";
    const url = `${DOCUMENTS_ENDPOINT}${query}`;
@@ -572,6 +590,20 @@ export function usePeers() {
    );
    return {
       peers: data,
+      error,
+      isLoading,
+      isValidating,
+      mutate
+   };
+}
+
+export function useRecentChats() {
+   const { data, error, isLoading, isValidating, mutate } = useSWR(
+      `${CHATS_ENDPOINT}/recent`,
+      fetcher
+   );
+   return {
+      chats: data,
       error,
       isLoading,
       isValidating,


### PR DESCRIPTION
### Description

- new dashboard screen with some useful info from documents and workspaces
- switched old dashboard content and put it to home screen

## Testing Instructions

- open app go to home route, see there is old dashboard content there
- open dashboard, there are new cards with some useful information there
- test if all translations are in place
- all cards in dashboard are clickable and they redirect to document or workspace in question

### Type of Change

Please delete options that are not relevant.

- [x] ✨ New feature

### Screenshots (if applicable)

<!-- Drag and drop screenshots here -->

### Related Issue

Closes #148 #132
