### PR TITLE
added copy command for copying openapi file

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -6,6 +6,7 @@ ENV NODE_ENV=development
 ENV CONTAINER=true
 
 COPY . . 
+COPY openapi ./dist/openapi
 
 RUN npm ci --include=dev  
 RUN npm run build 


### PR DESCRIPTION
### Description

* added missing command in BE dev dockerfile for copying openapi.yaml

## Testing Instructions

* just run app with start.sh and BE should work properly now

### Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Screenshots (if applicable)

<!-- Drag and drop screenshots here -->

### Related Issue

Closes #158 
