### PR TITLE
Feature: #163 Perspective actions dropdown

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -352,7 +352,8 @@
       "promptBodyPlaceholder": "Gib Deinen Prompt ein",
       "savePrompt": "Prompt speichern",
       "saveCustomPromptHint": "Das Speichern von Prompts funktioniert noch nicht",
-      "generateNewPerspectiveFromPrevious": "Mit KI anpassen"
+      "generateNewPerspectiveFromPrevious": "Mit KI anpassen",
+      "perspectiveActions": "Perspektivenaktionen"
    },
    "documentEditable": {
       "cancel": "Abbrechen",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -352,7 +352,8 @@
       "promptBodyPlaceholder": "Enter your prompt",
       "savePrompt": "Save prompt",
       "saveCustomPromptHint": "Saving prompts doesn't work",
-      "generateNewPerspectiveFromPrevious": "Adjust with AI"
+      "generateNewPerspectiveFromPrevious": "Adjust with AI",
+      "perspectiveActions": "Perspective actions"
    },
    "documentEditable": {
       "cancel": "Cancel",


### PR DESCRIPTION
### Description

- adjusted Perspectives component so that now we have dropdown which encapsulates 3 buttons for perspective actions

## Testing Instructions

- open app
- create workspace and add some document if you don't already have one
- go to document details and look in Perspective card
- there is now dropdown named Perspective actions and contains previous 3 buttons

### Type of Change

Please delete options that are not relevant.

- [x] ✨ New feature

### Screenshots (if applicable)

<!-- Drag and drop screenshots here -->

### Related Issue

Closes #163
