### PR TITLE
Fix-peers-count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ outputscribble.json
 ipfs-cluster-ctl
 ipfs-cluster-service
 scripts/prompts/cookies.txt
+.scratch

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -82,7 +82,7 @@ router.get("/", async (req: Request, res: Response) => {
 router.get("/peers", async (req: Request, res: Response) => {
   const peers = await new IpfsClient().getPeers();
 
-  res.json(peers.data);
+  res.json(peers);
 });
 
 export default router;

--- a/frontend/src/app/(ts)/statistics/page.tsx
+++ b/frontend/src/app/(ts)/statistics/page.tsx
@@ -61,7 +61,7 @@ export default function Statistics() {
             />
             <KPIBox
                kpi={statisticsTranslations("peerServers")}
-               value={peers?.cluster_peers?.length || "-"}
+               value={peers?.length || "-"}
                deltaColor="red-600"
                icon={<Server className="w-16 h-16" />}
                iconBgColor="blue-600"


### PR DESCRIPTION
### Description

Peer servers count in Statistics screen shows "-" when more than 1 peer server is connected. Cluster api returned data in whitespace delimited json, which wasn't parsed properly.

## Testing Instructions

You have to have at least two running clusters to reproduce the bug.
This MR should show the correct peer count.

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Screenshots (if applicable)

<!-- Drag and drop screenshots here -->
<img width="1111" height="457" alt="Screenshot 2025-08-06 at 11 25 01" src="https://github.com/user-attachments/assets/cc0cfa51-d900-44ce-812c-e61aa9d9a713" />


### Related Issue

Closes #173 