### PR TITLE
BUG: #194 fix app status peer error

### DIFF
--- a/frontend/src/app/(ts)/appStatus/page.tsx
+++ b/frontend/src/app/(ts)/appStatus/page.tsx
@@ -52,10 +52,11 @@ export default function AppStatus() {
    };
 
    const connectedNodes = peers?.length || 0;
-   const clusterPeers =
-      peers?.reduce((count: number, peer: PeerNode) => {
-         return count + (peer.cluster_peers?.length || 0);
-      }, 0) || 0;
+   const clusterPeers = Array.isArray(peers)
+      ? peers.reduce((count: number, peer: PeerNode) => {
+           return count + (peer.cluster_peers?.length || 0);
+        }, 0)
+      : 0;
 
    const loading = healthLoading || peersLoading;
 


### PR DESCRIPTION
### Description

- appStatus should no longer throw an error in incognito window

## Testing Instructions

- open incognito window
- go to localhost:3000/appStatus
- app should open appStatus if you are logged in or redirect to login page if not

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Screenshots (if applicable)

<!-- Drag and drop screenshots here -->

### Related Issue

Closes #194
