### PR TITLE
Disable chat send button during sending.

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -329,7 +329,8 @@
       "secondaryMessage": "Chat-Nachricht wird mit Punkt im Dokument verknüpft",
       "messagePlaceholder": "Gib eine Nachricht ein...",
       "downloadChatMessages": "Chat-Nachrichten herunterladen",
-      "send": "Senden"
+      "send": "Senden",
+      "sending": "Wird gesendet..."
    },
    "perspectives": {
       "addYourPerspective": "Füge deine Perspektive hinzu",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -329,7 +329,8 @@
       "secondaryMessage": "Chat message will be linked to point in document",
       "messagePlaceholder": "Type a message...",
       "downloadChatMessages": "Download chat messages",
-      "send": "Send"
+      "send": "Send",
+      "sending": "Sending..."
    },
    "perspectives": {
       "addYourPerspective": "Add your perspective",

--- a/frontend/src/app/(ts)/workspace/[workspaceId]/document/[documentId]/DocumentChat.tsx
+++ b/frontend/src/app/(ts)/workspace/[workspaceId]/document/[documentId]/DocumentChat.tsx
@@ -32,6 +32,7 @@ export default function DocumentChat({
    displayNote
 }) {
    const [loading, setLoading] = useState(true);
+   const [sending, setSending] = useState(false);
    const [error, setError] = useState(null);
    const [chats, setChats] = useState<Chat[] | null>(null);
    const [message, setMessage] = useState("");
@@ -66,6 +67,7 @@ export default function DocumentChat({
 
    const handleSubmit = async (e: React.FormEvent) => {
       e.preventDefault();
+      setSending(true);
       if (message === "") {
          setEmptyMessageError(true);
          return;
@@ -99,6 +101,7 @@ export default function DocumentChat({
       } finally {
          setNewNoteVisible(false);
          setTimeout(fetchChats, 1000);
+         setSending(false);
       }
    };
 
@@ -223,7 +226,9 @@ export default function DocumentChat({
                         </TooltipContent>
                      </Tooltip>
                   </TooltipProvider>
-                  <Button type="submit">{translations("send")}</Button>
+                  <Button type="submit" disabled={sending}>
+                     {sending ? translations("sending") : translations("send")}
+                  </Button>
                </div>
             </form>
          </div>


### PR DESCRIPTION
### Description

Disable chat send button during sending.

## Testing Instructions

- Open chat
- type message
- Try to send message multiple times

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Screenshots (if applicable)

<img width="437" height="230" alt="image" src="https://github.com/user-attachments/assets/d3d2a8d1-baa0-4b55-a87d-89978947b564" />

### Related Issue

Closes #209 
