### PR TITLE
Add check to not create duplicate owners

### DIFF
--- a/backend/src/routes/workspaces.ts
+++ b/backend/src/routes/workspaces.ts
@@ -147,12 +147,20 @@ router.put(
     try {
       await client.updateWorkspaceType(wUID, isPublic);
       if (isPublic === false) {
-        await createPermissionDb({
-          workspaceId: wUID,
-          email: req.user?.email as string,
-          role: "owner",
-          status: USER_PERMISSION_STATUS.active,
-        });
+        const currentPermissions = await findUsersInWorkspaceDb(wUID);
+        const currentUserPermissions = currentPermissions.find(
+          (perm) => perm.email === req.user?.email
+        );
+
+        // Only create permission if it doesn't exist
+        if (!currentUserPermissions) {
+          await createPermissionDb({
+            workspaceId: wUID,
+            email: req.user?.email as string,
+            role: "owner",
+            status: USER_PERMISSION_STATUS.active,
+          });
+        }
       } else {
         const usersInWs = await findUsersInWorkspaceDb(wUID);
         const workspaceDetails = await client.getWorkspaceById(wUID);


### PR DESCRIPTION
### Description

Added check to prevent duplicate owner of workspace

## Testing Instructions

- Create public workspace
- Switch it to private 
- Open share workspace screen
- Owner is not duplicated

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Screenshots (if applicable)

<!-- Drag and drop screenshots here -->

### Related Issue

Closes #212 
