### PR TITLE
Move creation of formdata when uploading doc into try/catch

### DIFF
--- a/frontend/src/components/DocumentUpload.tsx
+++ b/frontend/src/components/DocumentUpload.tsx
@@ -166,12 +166,13 @@ export default function DocumentUpload({
             );
             return;
          }
-         const formData = new FormData();
-         formData.append("workspace", workspace?.uuid);
-         formData.append("versionTagName", versionTagName);
-         formData.append("author", author);
-         formData.append("file", file, file.name);
          try {
+            const formData = new FormData();
+            formData.append("workspace", workspace?.uuid);
+            formData.append("versionTagName", versionTagName);
+            formData.append("author", author);
+            formData.append("file", file, file.name);
+
             const res = await documentUpload(
                formData,
                docId,


### PR DESCRIPTION
### Description

Bug fix where uploaded document error leads to crash of entire frontend

## Testing Instructions

Try with different documents, whether they lead to frontend crash

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Related Issue

Closes #222 
