### PR TITLE
Replace summary blocker with document tags in document list

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -408,7 +408,6 @@
       "documentCreated": "Dokument erfolgreich erstellt",
       "documentCreateError": "Beim Erstellen des Dokuments ist ein Fehler aufgetreten",
       "documentTooLargeError": "Dokument ist zu groß",
-      "summaryOf": "Zusammenfassung des Dokuments und der zugehörigen Tags",
       "details": "Details",
       "download": "Herunterladen",
       "versions": "Versionen",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -408,7 +408,6 @@
       "documentDeleted": "Document deleted successfully",
       "documentDeleteError": "An error occurred while deleting the document",
       "documentTooLargeError": "Document is too large",
-      "summaryOf": "Summary of document and related tags",
       "details": "Details",
       "download": "Download",
       "versions": "Versions",

--- a/frontend/src/app/(ts)/workspace/[workspaceId]/document/[documentId]/DocumentTags.tsx
+++ b/frontend/src/app/(ts)/workspace/[workspaceId]/document/[documentId]/DocumentTags.tsx
@@ -134,7 +134,7 @@ export default function DocumentTags({ cid, workspaceOrigin, docId, status }) {
    return (
       <div className="flex flex-col">
          <div className="h-full">
-            <div className="space-y-4">
+            <div className="space-y-4 mb-2">
                {isGenerating ? (
                   <div className="flex flex-col items-center justify-center">
                      <Loader2 className="animate-spin h-10 w-10 mb-2" />
@@ -149,7 +149,7 @@ export default function DocumentTags({ cid, workspaceOrigin, docId, status }) {
                         <Badge
                            key={tag.id}
                            variant="default"
-                           className={`mr-1 pr-1 mt-4 min-h-[30px] ${tag.color} ${getBadgeTextColor(tag.color)}`}
+                           className={`mr-1 pr-1 mt-2 min-h-[30px] ${tag.color} ${getBadgeTextColor(tag.color)}`}
                         >
                            {tag?.name.replace(/"/g, "")}
                            {tag?.creatorType === "ai" && (
@@ -176,7 +176,7 @@ export default function DocumentTags({ cid, workspaceOrigin, docId, status }) {
                      ))}
                   {!isAdding && !isGenerating && (
                      <Button
-                        className="h-6 mt-4 min-h-[30px]"
+                        className="h-6 mt-2 min-h-[30px]"
                         onClick={() => setIsAdding(true)}
                      >
                         <Plus />

--- a/frontend/src/components/DocumentList.tsx
+++ b/frontend/src/components/DocumentList.tsx
@@ -58,6 +58,7 @@ import {
    TooltipTrigger
 } from "./ui/tooltip";
 import PaginationComponent from "./Pagination";
+import DocumentTags from "../app/(ts)/workspace/[workspaceId]/document/[documentId]/DocumentTags";
 
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
    "pdfjs-dist/build/pdf.worker.min.mjs",
@@ -126,7 +127,7 @@ const DocumentList = ({ workspaceId }) => {
                   : row.original.meta.filename;
                return (
                   <div>
-                     <div className="text-lg font-bold mb-1 mt-3">
+                     <div className="text-lg font-bold mt-3">
                         {fileName}
                         {isEditableFile && (
                            <Badge className="ml-2">
@@ -134,9 +135,12 @@ const DocumentList = ({ workspaceId }) => {
                            </Badge>
                         )}
                      </div>
-                     <div className="font-thin">
-                        {documentTranslations("summaryOf")}
-                     </div>
+                      <DocumentTags
+                          cid={row.original.cid}
+                          workspaceOrigin={row.original.workspaceOrigin}
+                          docId={row.original.docId}
+                          status={row.original.status}
+                      />
                      <div className="font-semibold flex flex-inline mb-3">
                         {row.original.meta.creator} <Dot className="-mt-0.5" />{" "}
                         {fileSize} <Dot className="-mt-0.5" />{" "}


### PR DESCRIPTION
### Description

Display tags in the workspace overview

## Testing Instructions

Test if the tags are displayed correctly and if everything looks nice

### Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Screenshots (if applicable)

<img width="3628" height="1295" alt="image" src="https://github.com/user-attachments/assets/fe88a4a4-9164-4e94-ad11-935179c73bb2" />

### Related Issue

closes #231
