### PR TITLE
Allow all file types in document upload

### DIFF
--- a/frontend/src/components/DocumentUpload.tsx
+++ b/frontend/src/components/DocumentUpload.tsx
@@ -244,7 +244,6 @@ export default function DocumentUpload({
                         onChange={handleInputChange}
                         multiple
                         className="hidden"
-                        accept=".pdf,.doc,.docx,.txt,.ppt,.pptx,.xls,.xlsx,.png,.jpg,.jpeg"
                      />
                      <div className="flex items-center mt-2">
                         <Button


### PR DESCRIPTION
### Description

As described in #283 , allow all file types when uploading a document.

## Testing Instructions

In a workspace, click on "Document" > "Upload new document" then see if different file types e.g. .mp4 (previously not accepted) can be selected

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix

### Related Issue

Closes #283 
