### PR TITLE
Make username editable

### DIFF
--- a/backend/src/clients/db/users.ts
+++ b/backend/src/clients/db/users.ts
@@ -166,6 +166,18 @@ export const storeUserSettingsDb = async (
   }
 };
 
+export const updateUserName = async (email: string, name: string) => {
+  try {
+    await db<UserDb>("users")
+      .update({ username: name })
+      .where({ email: email });
+  }
+  catch (error) {
+    logger.error("Error updating user", error);
+    throw new Error("Error updating user");
+  }
+};
+
 export const updateUserPassword = async (
   userId: number,
   passwordHash: string

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -14,6 +14,7 @@ import {
   getTotalUsersDb,
   storeUserSettingsDb,
   updateUserFirstSignIn,
+  updateUserName,
   updateUserPassword,
   updateUserToken,
 } from "../clients/db";
@@ -523,6 +524,32 @@ router.post(
       res.status(500).json({
         status: "failure",
         message: "Unknown error occurred",
+      });
+    }
+  }
+);
+
+router.post(
+  "/reset-name",
+  authenticateCookie,
+  validate([body("name").isString().isLength({ min: 3 })]),
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const email = req.user?.email;
+      if (!email) {
+        return res.status(401).json({ message: "Unauthorized" });
+      }
+
+      await updateUserName(email, req.body.name);
+      return res.json({
+        status: "success",
+        message: "Name updated successfully",
+      });
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({
+        status: "failure",
+        message: "Could not update name",
       });
     }
   }

--- a/frontend/src/app/(ts)/userSettings/page.tsx
+++ b/frontend/src/app/(ts)/userSettings/page.tsx
@@ -18,10 +18,10 @@ import {
    SelectValue
 } from "@/components/ui/select";
 import { useUser } from "@/contexts/UserContext";
-import { updateUserSettings } from "@/lib/services";
+import { updateUserSettings, updateUserName } from "@/lib/services";
 
 export default function UserSettings() {
-   const { user, loading, updatePreferedLanguage, updateAvatar, refreshUser } =
+   const { user, loading, updatePreferedLanguage, updateUser, updateAvatar, refreshUser } =
       useUser();
    const [file, setFile] = useState<File>();
    const [selectedLanguage, setSelectedLanguage] = useState<string>();
@@ -82,6 +82,18 @@ export default function UserSettings() {
          setSettingChanged(true);
       }
    };
+
+   const handleNameChange = async (
+      e: React.KeyboardEvent<HTMLInputElement>
+    ) => {
+        const name = e.currentTarget.value;
+
+        if (user && name !== user.name) {
+            updateUser({ name });
+            await updateUserName(name);
+            setSettingChanged(true);
+        }
+    }
 
    const handlePreferedLanguageChange = (language) => {
       setSelectedLanguage(language);
@@ -170,9 +182,14 @@ export default function UserSettings() {
                <Label htmlFor="name">{registerTranslations("name")}</Label>
                <Input
                   id="name"
+                  type="text"
                   className="p-2 bg-slate-50 dark:bg-slate-800 dark:text-white dark:placeholder:text-white"
                   defaultValue={user.name}
-                  disabled
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      handleNameChange(e);
+                    }
+                  }}
                />
             </div>
             <div>

--- a/frontend/src/lib/services.ts
+++ b/frontend/src/lib/services.ts
@@ -702,6 +702,28 @@ export const updateUserSettings = async (formData: FormData) => {
    }
 };
 
+export const updateUserName = async (name: string) => {
+    try {
+        const res = await fetch(`${USERS_ENDPOINT}/reset-name`, {
+            method: "POST",
+            credentials: "include",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({ name })
+        });
+
+        if (!res.ok) {
+            throw new Error("Failed to update user name");
+        }
+        return res.json();
+    }
+    catch (error) {
+        console.error("Error updating user name:", error);
+        throw error;
+    }
+};
+
 export const downloadAvatar = async () => {
    try {
       const res = await fetch(`${USERS_ENDPOINT}/avatar`, {


### PR DESCRIPTION
### Description

Give users the option to rename their user name

#### Old version, non editable
<img width="976" height="1518" alt="image" src="https://github.com/user-attachments/assets/7294cee5-ac43-4a2a-97db-0bfc8d1e192e" />

#### New version, editable
You can change the username by clicking into the name, typing the new name and entering it.
<img width="1045" height="1519" alt="image" src="https://github.com/user-attachments/assets/ff879e77-7d52-4614-9cca-1aad419ff954" />

In the next screenshots, you can see 2 comments from the same user before and after the user name change:
<img width="2161" height="2365" alt="image" src="https://github.com/user-attachments/assets/0cd95a1d-31c7-4ef2-98cf-efb6bc575ceb" />

Note that if a user name changes, the prior elements with the "old" user name e.g. author, comment user, workspace creator, etc. don't get updated so there is a discrepancy at the moment! @jzakotnik to be discussed whether this would even possible in ipfs to update the names from older elements or not.

### Type of Change

- [x] ✨ New feature

### Related Issue

Closes #257 
