### PR TITLE
Add --dev flag to start script for no user input

### DIFF
--- a/.github/workflows/main-pr.yml
+++ b/.github/workflows/main-pr.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Start app, wait for health, then stop
         run: |
           echo "Starting application..."
-          ./start.sh &
+          ./start.sh --dev &
           APP_PID=$!
           echo $APP_PID > app.pid
 

--- a/scripts/configure-env.sh
+++ b/scripts/configure-env.sh
@@ -18,6 +18,19 @@ EMPTY="empty"
 source "${SCRIPT_DIR}/libs/logging.sh"
 
 #──────────────────────────────────────────────────────────────────────────────
+# PARSE ARGUMENTS
+#──────────────────────────────────────────────────────────────────────────────
+DEV="false"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --dev)
+      DEV="true"
+      shift
+      ;;
+  esac
+done
+
+#──────────────────────────────────────────────────────────────────────────────
 # FUNCTIONS
 #──────────────────────────────────────────────────────────────────────────────
 
@@ -296,7 +309,13 @@ PROFILE_PRODUCTION="production - Prefills stable, reliable defaults that work in
 PROFILE_CUSTOM="custom - No defaults; you can specify every value"
 
 # PROFILE
-prompt_var PROFILE choice "Specify an environment profile to prefill selected settings" "$PROFILE_DEVELOPMENT" "$PROFILE_DEVELOPMENT" "$PROFILE_PRODUCTION" "$PROFILE_CUSTOM"
+# Do not prompt if --dev flag is set (then development profile is used automatically)
+if [ "$DEV" = "true" ]; then
+  PROFILE="$PROFILE_DEVELOPMENT"
+  echo_success "DEV mode detected, using 'development' profile."
+else
+  prompt_var PROFILE choice "Specify an environment profile to prefill selected settings" "$PROFILE_DEVELOPMENT" "$PROFILE_DEVELOPMENT" "$PROFILE_PRODUCTION" "$PROFILE_CUSTOM"
+fi
 
 case "$PROFILE" in
   "$PROFILE_DEVELOPMENT")

--- a/start.sh
+++ b/start.sh
@@ -106,9 +106,16 @@ if [[ "$CONFIGURE_ENV" = "true" || ! -f "$ENV_FILE" ]]; then
   chmod +x "$CONFIGURE_ENV_SCRIPT"
 
   # Execute script and wait for completion
-  if ! $CONFIGURE_ENV_SCRIPT; then
+  if [ "$DEV" = "true" ]; then
+    if ! $CONFIGURE_ENV_SCRIPT --dev; then
     echo_error "Failed to generate .env file."
     exit 1
+    fi
+  else
+    if ! $CONFIGURE_ENV_SCRIPT; then
+        echo_error "Failed to generate .env file."
+        exit 1
+    fi
   fi
 
   echo_success ".env configuration completed"


### PR DESCRIPTION
### Description

`--dev` flag for `start.sh` and therefore also `configure-env.sh` to require no user input at all.

## Testing Instructions

Run `bash start.sh --dev` and see if it runs without problems with development profile.

### Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor

### Related Issue

Closes #300 
