### PR TITLE
Change preview label to Editor for editable files

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -229,6 +229,7 @@
    "documentPreview": {
       "preview": "Vorschau",
       "noPreview": "Keine Vorschau verfügbar",
+      "editor": "Editor",
       "unsupportedFormat": "Dieses Dateiformat wird für die Vorschau nicht unterstützt",
       "page": "Seite",
       "of": "von"

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -229,6 +229,7 @@
    "documentPreview": {
       "preview": "Preview",
       "noPreview": "No Preview Available",
+      "editor": "Editor",
       "unsupportedFormat": "This file format is not supported for preview.",
       "page": "Page",
       "of": "of"

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -229,6 +229,7 @@
   "documentPreview": {
     "preview": "Avance",
     "noPreview": "No hay vista previa disponible",
+    "editor": "Editor",
     "unsupportedFormat": "Este formato de archivo no es compatible con la vista previa",
     "page": "Página",
     "of": "de"

--- a/frontend/src/app/(ts)/workspace/[workspaceId]/document/[documentId]/page.tsx
+++ b/frontend/src/app/(ts)/workspace/[workspaceId]/document/[documentId]/page.tsx
@@ -164,9 +164,13 @@ export default function DocumentDetailsPage() {
                   disabled={!isPreviewAvailable}
                   className="data-[state=active]:bg-blue-500 data-[state=active]:dark:bg-blue-800 data-[state=active]:text-white"
                >
-                  {isPreviewAvailable
-                     ? documentPreviewTranslations("preview")
-                     : documentPreviewTranslations("noPreview")}
+                 {
+                   isRichTextDocument
+                     ? documentPreviewTranslations("editor")
+                     : isPreviewAvailable
+                       ? documentPreviewTranslations("preview")
+                       : documentPreviewTranslations("noPreview")
+                 }
                </TabsTrigger>
                <TabsTrigger
                   value="versions"


### PR DESCRIPTION
### Description

For editable files, change the preview label from "Preview" to "Editor"

## Testing Instructions

Run application and check for editable file and another file type if the preview labels are correct

### Type of Change

Please delete options that are not relevant.

- [x] ✨ New feature

### Screenshots (if applicable)

For editable file:
<img width="2277" height="909" alt="image" src="https://github.com/user-attachments/assets/87b7be3b-f189-4cff-945c-45d56c207494" />

For Word: 
<img width="2236" height="338" alt="image" src="https://github.com/user-attachments/assets/ec5d4c23-546c-4ae7-a000-1796e31ca04c" />


### Related Issue

Closes #315 
