### PR TITLE
Add Docker logs with rotation

### DIFF
--- a/docker-compose-ai.yml
+++ b/docker-compose-ai.yml
@@ -21,3 +21,8 @@ services:
     volumes:
       - ./volumes/open-webui:/app/backend/data
       - ./volumes/ollama:/root/.ollama/models
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docker-compose-frontend.yml
+++ b/docker-compose-frontend.yml
@@ -8,3 +8,8 @@ services:
       TRUSPACE_VERSION: ${TRUSPACE_VERSION}
     ports:
       - ${FRONTEND_PORT}:${FRONTEND_PORT}
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,11 @@ services:
     entrypoint: sh ./entrypoint.sh
     volumes:
       - ./volumes/db:/app/data
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   ##################################################################################
   ## IPFS & Cluster PEER 0 #########################################################
@@ -55,6 +60,11 @@ services:
         - ./volumes/ipfs0:/data/ipfs
         - ./scripts/init-ipfs-config.sh:/init-ipfs-config.sh:ro
     entrypoint: ["/init-ipfs-config.sh", "${SWARM_PORT}", "${IPFS_API_PORT}", "${IPFS_GATEWAY_PORT}"] # Custom entrypoint to setup network settings with no bootstrapping
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   cluster0:
     container_name: cluster0
@@ -79,3 +89,8 @@ services:
       - "${CLUSTER_SWARM_PORT}:${CLUSTER_SWARM_PORT}"
     volumes:
       - ./volumes/cluster0:/data/ipfs-cluster
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
### Description

Add Docker logs with rotation with the following restrictions:
- max 10mb
- max 3 last files

## Testing Instructions

Run TruSpace, stop containers and check if you can access the logs

### Type of Change

Please delete options that are not relevant.

- [x] ✨ New feature

### Related Issue

Closes #259 
