### PR TITLE
Separate download avatar cid and file

### DIFF
--- a/backend/src/modules/users/application/get-users-avatar.usecase.ts
+++ b/backend/src/modules/users/application/get-users-avatar.usecase.ts
@@ -1,10 +1,9 @@
 import { findUserByEmailDb } from '../../../shared/clients/db';
-import { AvatarNotFoundError } from '../errors/avatar-not-found.error';
 
 export async function getUsersAvatar(email: string) {
   const user = await findUserByEmailDb(email);
   if (!user?.avatar_cid) {
-    throw new AvatarNotFoundError();
+     return null;
   }
 
   return user.avatar_cid;

--- a/backend/src/modules/users/errors/avatar-not-found.error.ts
+++ b/backend/src/modules/users/errors/avatar-not-found.error.ts
@@ -1,7 +1,0 @@
-import { NotFoundError } from '../../../shared/errors';
-
-export class AvatarNotFoundError extends NotFoundError {
-  constructor(details?: unknown) {
-    super(`Avatar not found`, details);
-  }
-}

--- a/backend/src/modules/users/presentation/users.controller.ts
+++ b/backend/src/modules/users/presentation/users.controller.ts
@@ -64,9 +64,14 @@ export const UsersController = {
     res.json(result);
   },
 
-  getUsersAvatar: async (req: AuthenticatedRequest, res: Response) => {
-    const cid = await getUsersAvatar(req.user?.email as string);
-    return new IpfsClient().downloadAvatar(req, res, cid);
+   getUsersAvatarCid: async (req: AuthenticatedRequest, res: Response) => {
+      const cid = await getUsersAvatar(req.user?.email as string);
+      res.json({ cid });
+   },
+
+   getUsersAvatar: async (req: AuthenticatedRequest, res: Response) => {
+     const cid = req.params.cid as string;
+     return new IpfsClient().downloadAvatar(req, res, cid);
   },
 
   postUsersForgotPassword: async (req: Request, res: Response) => {

--- a/backend/src/modules/users/presentation/users.routes.ts
+++ b/backend/src/modules/users/presentation/users.routes.ts
@@ -43,6 +43,8 @@ usersRouter.get('/users/statistics', authenticateCookie, UsersController.getUser
 
 usersRouter.get('/users/user-settings', authenticateCookie, UsersController.getUsersUserSettings);
 
-usersRouter.get('/users/avatar', authenticateCookie, UsersController.getUsersAvatar);
+usersRouter.get('/users/avatar-cid', authenticateCookie, UsersController.getUsersAvatarCid);
+
+usersRouter.get('/users/avatar/:cid', authenticateCookie, UsersValidator.getUsersAvatar, UsersController.getUsersAvatar);
 
 usersRouter.delete('/users/delete-user', authenticateCookie, UsersController.deleteUser);

--- a/backend/src/modules/users/presentation/users.validators.ts
+++ b/backend/src/modules/users/presentation/users.validators.ts
@@ -1,4 +1,4 @@
-import { body, query } from 'express-validator';
+import { body, param, query } from 'express-validator';
 
 import validate from '../../../shared/middlewares/validate';
 
@@ -28,5 +28,7 @@ export const UsersValidator = {
 
   postUsersResetName: validate([body('name').isString().isLength({ min: 3 })]),
 
-  postUsersResetPassword: validate([body('password').isString(), body('token').isString()]),
+   postUsersResetPassword: validate([body('password').isString(), body('token').isString()]),
+
+   getUsersAvatar: validate([param('cid').isString().notEmpty()]),
 };

--- a/backend/src/shared/clients/ipfs-client/index.ts
+++ b/backend/src/shared/clients/ipfs-client/index.ts
@@ -80,7 +80,7 @@ export class IpfsClient implements IClient {
 
   async downloadAvatar(req: AuthenticatedRequest, res: Response, cid: string): Promise<any> {
     try {
-      const result = await this.#gatewayAxios.get(`/ipfs/${cid}`, {
+      const result = await this.#gatewayAxios.get(`/ipfs/${encodeURIComponent(cid)}`, {
         responseType: 'arraybuffer',
       });
 

--- a/frontend/src/contexts/UserContext.tsx
+++ b/frontend/src/contexts/UserContext.tsx
@@ -15,6 +15,7 @@ import Cookies from "js-cookie";
 
 import { COOKIE_NAME, deleteLoginCookie, setLoginCookie } from "@/lib";
 import {
+   downloadAvatarCid,
    downloadAvatar,
    downloadUserSettings,
    logout as apiLogout
@@ -158,7 +159,14 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
             );
          }
 
-         const response = await downloadAvatar();
+         const avatar_cid = await downloadAvatarCid();
+
+         if (!avatar_cid) {
+            // No avatar uploaded yet — expected for new users
+            return null;
+         }
+
+         const response = await downloadAvatar(avatar_cid);
 
          if (!response) {
             // No avatar uploaded yet — expected for new users

--- a/frontend/src/lib/services.ts
+++ b/frontend/src/lib/services.ts
@@ -804,9 +804,32 @@ export const removeAllUserPermissions = async (email: string) => {
     }
 };
 
-export const downloadAvatar = async () => {
+export const downloadAvatarCid = async () => {
    try {
-      const res = await fetch(`${USERS_ENDPOINT}/avatar`, {
+      const res = await fetch(`${USERS_ENDPOINT}/avatar-cid`, {
+         method: "GET",
+         credentials: "include"
+      });
+
+      if (res.status === 404) {
+         return null;
+      }
+
+      if (!res.ok) {
+         throw new Error("Failed to download avatar CID");
+      }
+
+      const result = await res.json();
+      return result.cid;
+   } catch (error) {
+      console.error("Error downloading avatar CID:", error);
+      throw error;
+   }
+}
+
+export const downloadAvatar = async (avatarCid: string) => {
+   try {
+      const res = await fetch(`${USERS_ENDPOINT}/avatar/${encodeURIComponent(avatarCid)}`, {
          method: "GET",
          credentials: "include"
       });


### PR DESCRIPTION
### Description

When trying to fetch the avatar, we always threw a 404 NOT FOUND error when a user hadn't uploaded an image yet (which we already handle in the frontend by displaying the initials).

Now, before trying to fetch the image file in IPFS, we check if we have an avatar_cid stored for that user and only then try to fetch the file. Thus, the not found error should not be thrown anymore.

## Testing Instructions

Run the application and check in the backend logs, if the 404 error is still thrown. Also check if the avatar is loaded properly when an image was uploaded.

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix

### Related Issue

Closes #342 