### PR TITLE
fix(job-queue): register default job templates

### DIFF
--- a/backend/src/shared/clients/ipfs-client/index.ts
+++ b/backend/src/shared/clients/ipfs-client/index.ts
@@ -1451,18 +1451,6 @@ export class IpfsClient implements IClient {
           updated_at: element.pin.meta.updated_at,
         }),
       );
-      console.log(
-        JSON.stringify(
-          {
-            fetch: `/pins?limit=${maxNumberOfFetchedPins}&meta={"type":"permission","${key}":"${encodedValue}"}`,
-            key,
-            value,
-            results,
-          },
-          null,
-          2,
-        ),
-      );
       return results;
     } catch (error) {
       logger.error('Error getting event data:', error);

--- a/backend/src/shared/utility/jobQueue.ts
+++ b/backend/src/shared/utility/jobQueue.ts
@@ -8,6 +8,7 @@ import {
 } from '../clients/db/jobStatus';
 import logger from '../config/winston';
 import { Prompt } from '../types/interfaces';
+import { registerDefaultJobTemplates } from './jobTemplates';
 
 type JobStatus = 'pending' | 'processing' | 'completed' | 'failed' | null;
 
@@ -38,6 +39,7 @@ class JobQueue {
 
   constructor(useDatabase = false) {
     this.#useDatabase = useDatabase;
+    registerDefaultJobTemplates(this);
 
     if (this.#useDatabase) {
       getJobNotFinishedAndResetStatusesDb()

--- a/backend/src/shared/utility/jobTemplates.ts
+++ b/backend/src/shared/utility/jobTemplates.ts
@@ -3,14 +3,20 @@ import { oiClient } from "../clients/oi-client";
 import logger from "../config/winston";
 import { createDocumentRequest } from "../handlers/documents";
 import { Prompt } from "../types/interfaces";
-import TaskQueue from "../utility/jobQueue";
 
-export const addPerspectivesTemplate = () =>
-  TaskQueue.addJobTemplate({
+type JobAttributes = { [key: string]: string | number | boolean | Prompt[] };
+
+type JobTemplateRegistrar = {
+  addJobTemplate(args: {
+    templateId: string;
+    job: (attributes: JobAttributes) => Promise<any>;
+  }): void;
+};
+
+export const addPerspectivesTemplate = (taskQueue: JobTemplateRegistrar) =>
+  taskQueue.addJobTemplate({
     templateId: "perspectives",
-    job: async (attributes: {
-      [key: string]: string | number | boolean | Prompt[];
-    }) => {
+    job: async (attributes: JobAttributes) => {
       const { cid, prompts, requestId } = attributes as {
         cid: string;
         prompts: Prompt[];
@@ -60,12 +66,10 @@ export const addPerspectivesTemplate = () =>
     },
   });
 
-export const addTagsTemplate = () =>
-  TaskQueue.addJobTemplate({
+export const addTagsTemplate = (taskQueue: JobTemplateRegistrar) =>
+  taskQueue.addJobTemplate({
     templateId: "tags",
-    job: async (attributes: {
-      [key: string]: string | number | boolean | Prompt[];
-    }) => {
+    job: async (attributes: JobAttributes) => {
       const { cid, prompts, requestId } = attributes as {
         cid: string;
         prompts: Prompt[];
@@ -114,12 +118,10 @@ export const addTagsTemplate = () =>
     },
   });
 
-export const addLanguageDetectionTemplate = () => {
-  TaskQueue.addJobTemplate({
+export const addLanguageDetectionTemplate = (taskQueue: JobTemplateRegistrar) => {
+  taskQueue.addJobTemplate({
     templateId: "language",
-    job: async (attributes: {
-      [key: string]: string | number | boolean | Prompt[];
-    }) => {
+    job: async (attributes: JobAttributes) => {
       const { cid } = attributes as {
         cid: string;
       };
@@ -164,4 +166,18 @@ export const addLanguageDetectionTemplate = () => {
       );
     },
   });
+};
+
+let defaultTemplatesRegistered = false;
+
+export const registerDefaultJobTemplates = (taskQueue: JobTemplateRegistrar) => {
+  if (defaultTemplatesRegistered) {
+    return;
+  }
+
+  addPerspectivesTemplate(taskQueue);
+  addTagsTemplate(taskQueue);
+  addLanguageDetectionTemplate(taskQueue);
+
+  defaultTemplatesRegistered = true;
 };


### PR DESCRIPTION
### Description

This PR fixes missing job template registration during backend startup.

The queue was trying to restore pending jobs from the database before the perspectives, tags, and language templates had been registered, which caused errors like Job template "perspectives" not found.

## Testing Instructions

Upload a File, AI should add a Perspective, Tags and there should be no error messages in the backend log

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix