### PR TITLE
Drop automatic release version jump for version checks

### DIFF
--- a/.github/workflows/main-pr.yml
+++ b/.github/workflows/main-pr.yml
@@ -1,7 +1,8 @@
 # On pull request to 'main' branch
 # A) Make sure that the pull request comes from 'main' branch
-# B) Scan for npm vulnerabilities
-# C) Test whether application starts
+# B) Make sure that release version (VERSION file) is different than on 'main' branch but aligned with version in publiccode.yml
+# C) Scan for npm vulnerabilities
+# D) Test whether application starts
 # parallel to A) In codeql.yml, run code scanning
 
 name: Protect PRs to `main`
@@ -25,10 +26,48 @@ jobs:
             echo "✅ PR is from `dev`."
           fi
 
+  new_version:
+    name: Ensure release version is updated
+    runs-on: ubuntu-latest
+    needs: restrict_pr
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch main branch
+        run: git fetch origin main
+
+      - name: Read VERSION from main
+        id: main_version
+        run: echo "MAIN_VERSION=$(git show origin/main:VERSION)" >> $GITHUB_OUTPUT
+
+      - name: Read VERSION from PR branch
+        id: pr_version
+        run: echo "PR_VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
+
+      - name: Compare versions
+        run: |
+          if [ "${{ steps.pr_version.outputs.PR_VERSION }}" = "${{ steps.main_version.outputs.MAIN_VERSION }}" ]; then
+            echo "❌ Release version in PR (VERSION) must be different than on main branch."
+            exit 1
+          else
+            echo "✅ Release version has been updated in PR."
+          fi
+
+      - name: Make sure version in publiccode.yml matches VERSION file
+        run: |
+          PR_VERSION=$(cat VERSION)
+          YML_VERSION=$(grep '^softwareVersion:' publiccode.yml | awk '{print $2}')
+          if [ "$PR_VERSION" != "$YML_VERSION" ]; then
+            echo "❌ Version in publiccode.yml ($YML_VERSION) does not match VERSION file ($PR_VERSION)."
+            exit 1
+          else
+            echo "✅ Version in publiccode.yml matches VERSION file."
+          fi
+
   npm_audit_backend:
     name: Scan backend for npm vulnerabilities
     runs-on: ubuntu-latest
-    needs: restrict_pr
+    needs: new_version
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -1,6 +1,6 @@
 # On push to 'main' branch
 # A) In docker-images.yml, build and scan images and if successful, push to Docker Hub
-# B) On workflow_run completion, bump version, create GitHub release and publish
+# B) On workflow_run completion, create GitHub release and publish
 
 name: Create and publish release
 
@@ -21,52 +21,23 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up Git
         run: |
           git config user.name "github-actions"
           git config user.email "actions@github.com"
 
-      - name: Bump version
-        id: version
-        run: |
-          # Read current version from VERSION file
-          OLD=$(cat VERSION)
-          echo "Old version: $OLD"
-
-          # Remove leading 'v' if exists and split
-          NUM=${OLD#v}
-          IFS='.' read -r MAJ MIN <<< "$NUM"
-          MIN=$((MIN+1))
-          NEW="v$MAJ.$MIN"
-
-          # Write back to VERSION
-          echo "$NEW" > VERSION
-          echo "New version: $NEW"
-
-          # Update publiccode.yml to read from VERSION
-          sed -i "s/^softwareVersion:.*/softwareVersion: $NEW/" publiccode.yml
-
-          echo "new_version=$NEW" >> $GITHUB_OUTPUT
-
-      - name: Commit new version to main
-        run: |
-          git add VERSION publiccode.yml
-          git commit -m "Bump version to ${{ steps.version.outputs.new_version }}"
-          git push origin main
-
-      - name: Push version bump to dev
-        run: |
-          git checkout main
-          git branch -D dev || true
-          git checkout -b dev
-          git push origin dev --force
+      - name: Read VERSION
+        id: get_version
+        run: echo "VERSION=$(cat VERSION | tr -d '[:space:]')" >> $GITHUB_OUTPUT
 
       - name: Create Release
         uses: actions/create-release@v1
         with:
-          tag_name: ${{ steps.version.outputs.new_version }}
-          release_name: Release ${{ steps.version.outputs.new_version }}
+          tag_name: ${{ github.event.workflow_run.head_branch }}-v${{ steps.get_version.outputs.VERSION }}
+          release_name: Release ${{ github.event.workflow_run.head_branch }}-v${{ steps.get_version.outputs.VERSION }}
           body: |
             Auto-generated release
           draft: false

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,4 +1,7 @@
-
 {
-  "tab_size": 3
+  "languages": {
+    "TypeScript": {
+      "tab_size": 3
+    }
+  }
 }


### PR DESCRIPTION
### Description

Instead of automatically bumping the release version, do it manually. For every PR to `main`, there is now a check if the version has changed (which it should) and if it is aligned to `publiccode.yml`.

### Related Issue

Closes #353 
