### PR TITLE
Add option to use CA certificate for connection to SMTP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,7 @@ SMTP_PORT=1025
 SMTP_SSL=false
 SMTP_TLS=false
 EMAIL_SENDER="TruSpace <truspace@truspace.com>"
+USE_STORED_CERTIFICATE=false  # If true, the certificate should be stored in volumes/general/smtp
 
 ##############################################################
 # 🖥️ OpenWebUI Admin Settings used for AI processing, see https://openwebui.com/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ scripts/prompts/cookies.txt
 doc/mkdocs/site
 frontend/public/terms/*
 .codex
+*.crt
+*.pem

--- a/backend/src/shared/config/config.ts
+++ b/backend/src/shared/config/config.ts
@@ -58,6 +58,8 @@ interface Config {
     tls: boolean;
     user: string;
     password: string;
+    useStoredCertificate: boolean;
+    certificatePath: string;
   };
   emailSender: string;
 }
@@ -132,6 +134,8 @@ export const config: Config = {
     tls: envVars.SMTP_TLS,
     user: envVars.SMTP_USER,
     password: envVars.SMTP_PASSWORD,
+    useStoredCertificate: envVars.USE_STORED_CERTIFICATE,
+    certificatePath: envVars.SMTP_CERTIFICATE_PATH,
   },
   emailSender: envVars.EMAIL_SENDER,
 };

--- a/backend/src/shared/config/envVarsSchema.ts
+++ b/backend/src/shared/config/envVarsSchema.ts
@@ -75,6 +75,8 @@ export const envVarsSchema = Joi.object({
   SMTP_USER: Joi.string().allow("").empty("").default(""),
   SMTP_PASSWORD: Joi.string().allow("").empty("").default(""),
   EMAIL_SENDER: Joi.string().allow("").empty("").default(""),
+  USE_STORED_CERTIFICATE: Joi.boolean().optional().allow("").empty("").default(false),
+  SMTP_CERTIFICATE_PATH: Joi.string().allow("").empty("").default("/app/smtp/ca.crt"),
   REGISTER_USERS_AS_INACTIVE: Joi.boolean()
     .optional()
     .allow("")

--- a/backend/src/shared/mailing/mailing.ts
+++ b/backend/src/shared/mailing/mailing.ts
@@ -1,6 +1,7 @@
 import nodemailer from "nodemailer";
 import SMTPConnection from "nodemailer/lib/smtp-connection";
 import * as SMTPTransport from "nodemailer/lib/smtp-transport";
+import fs from "fs";
 import { config } from "../config/config";
 import logger from "../config/winston";
 
@@ -18,6 +19,22 @@ export async function sendEmail(
           pass: smtpServer.password,
         };
 
+  let ca: Buffer | undefined;
+  if (smtpServer.useStoredCertificate) {
+    try {
+      ca = fs.readFileSync(smtpServer.certificatePath);
+      logger.info(`SMTP: loaded CA certificate from ${smtpServer.certificatePath}`);
+    } catch (err) {
+      logger.error(
+        `SMTP: USE_STORED_CERTIFICATE is true but certificate could not be read from ${smtpServer.certificatePath}: ${err}`
+      );
+      throw new Error(
+        `SMTP CA certificate not found at ${smtpServer.certificatePath}. ` +
+        `Please place the certificate file there or set USE_STORED_CERTIFICATE=false.`
+      );
+    }
+  }
+
   const transportOptions: SMTPTransport.Options = {
     host: smtpServer.host,
     port: smtpServer.port,
@@ -25,6 +42,7 @@ export async function sendEmail(
     // use STARTTLS, not SSL on connect
     requireTLS: smtpServer.tls,
     auth,
+    tls: ca ? { ca } : undefined,
   };
 
   const transporter = nodemailer.createTransport(transportOptions);

--- a/doc/mkdocs/docs/configuration/smtp.md
+++ b/doc/mkdocs/docs/configuration/smtp.md
@@ -1,0 +1,15 @@
+# SMTP CA Certificate
+
+Place your SMTP server's CA certificate here as `ca.crt` to resolve TLS
+"unknown issuer" errors when connecting to a mail server that uses a
+self-signed or privately-issued certificate.
+
+**Steps:**
+
+1. Export the CA certificate from your mail server (PEM format, `.crt`).
+2. Copy it to this directory in `volumes/general/smtp/` as `ca.crt`.
+3. Set `USE_STORED_CERTIFICATE=true` in your `.env` file.
+4. Restart the backend container.
+
+The file is mounted into the backend container at `/app/smtp/ca.crt` (read-only).
+Do **not** commit actual certificate files — add `*.crt` and `*.pem` to `.gitignore`.

--- a/doc/mkdocs/docs/configuration/smtp.md
+++ b/doc/mkdocs/docs/configuration/smtp.md
@@ -12,4 +12,3 @@ self-signed or privately-issued certificate.
 4. Restart the backend container.
 
 The file is mounted into the backend container at `/app/smtp/ca.crt` (read-only).
-Do **not** commit actual certificate files — add `*.crt` and `*.pem` to `.gitignore`.

--- a/doc/mkdocs/docs/getting-started/installation/remote.md
+++ b/doc/mkdocs/docs/getting-started/installation/remote.md
@@ -133,7 +133,7 @@ USE_REVERSE_PROXY - Are you using a reverse proxy (nginx, Caddy, Traefik)
 **Remaining prompts** (both scenarios)
 
 - **Master password** — minimum 8 characters; the default `Kennwort123` is rejected.
-- **SMTP settings** — for registration confirmation and password-reset emails. Press ENTER to skip if you don't have an SMTP server yet.
+- **SMTP settings** — for registration confirmation and password-reset emails. Press ENTER to skip if you don't have an SMTP server yet. If you have an external mail server and have to hand over the certificate, activate `USE_STORED_CERTIFICATE` and place the CA certificate in `./volumes/general/smtp/ca.crt` (see [README](../../configuration/smtp.md) for details).
 - **Open WebUI admin email and password** — for the AI management interface.
 - **`REGISTER_USERS_AS_INACTIVE`** — when enabled, new accounts need admin approval before they can log in (requires working SMTP or manual database access).
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -11,6 +11,7 @@ services:
       - ./backend/index.ts:/app/index.ts
       - ./backend/nodemon.json:/app/nodemon.json
       - ./backend/prompts:/app/prompts
+      - ./volumes/general/smtp:/app/smtp:ro
 
   frontend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,12 +36,15 @@ services:
       SMTP_SSL: ${SMTP_SSL}
       SMTP_TLS: ${SMTP_TLS}
       EMAIL_SENDER: ${EMAIL_SENDER}
+      USE_STORED_CERTIFICATE: ${USE_STORED_CERTIFICATE:-false}
+      SMTP_CERTIFICATE_PATH: /app/smtp/ca.crt
     ports:
       - ${API_PORT}:${API_PORT}
     entrypoint: sh ./entrypoint.sh
     volumes:
       - ./volumes/db:/app/data
       - ./volumes/clamav-scan:/scan
+      - ./volumes/general/smtp:/app/smtp:ro
     logging:
       driver: json-file
       options:

--- a/scripts/configure-env.sh
+++ b/scripts/configure-env.sh
@@ -340,6 +340,7 @@ case "$PROFILE_KEY" in
     SMTP_SSL=false
     SMTP_TLS=false
     EMAIL_SENDER="\"TruSpace <truspace@localhost>\""
+    USE_STORED_CERTIFICATE=false  # If true, the certificate should be stored in volumes/general/smtp
     # CSP (empty — no external resources)
     CONTENT_SECURITY_POLICY_DEFAULT_URLS="$EMPTY"
     CONTENT_SECURITY_POLICY_IMG_URLS="$EMPTY"
@@ -567,6 +568,7 @@ prompt_var SMTP_USER     text "SMTP username (leave blank if not required)" "$EM
 prompt_var SMTP_PASSWORD text "SMTP password (leave blank if not required)" "$EMPTY"
 prompt_var EMAIL_SENDER  text "Sender name and address shown in emails" \
   "\"TruSpace <truspace@${DOMAIN:-localhost}>\""
+prompt_var USE_STORED_CERTIFICATE  bool "Use stored certificate for SMTP? (necessary if external SMTP with STARTTLS or SSL, store cert in volumes/general/smtp)" false
 
 #──────────────────────────────────────────────────────────────────────────────
 # CSP CONFIGURATION
@@ -790,6 +792,7 @@ SMTP_TLS=${SMTP_TLS}
 SMTP_USER=${SMTP_USER}
 SMTP_PASSWORD=${SMTP_PASSWORD}
 EMAIL_SENDER=${EMAIL_SENDER}
+USE_STORED_CERTIFICATE=${USE_STORED_CERTIFICATE}
 
 #──────────────────────────────────────────────────────────────────────────────
 # 🛡️ Content Security Policy

--- a/start.sh
+++ b/start.sh
@@ -160,7 +160,7 @@ dirs=(
   "./volumes/db"
   "./volumes/db0"
   "./volumes/db1"
-  "./volumes/general"
+  "./volumes/general/smtp"
   "./volumes/ipfs0"
   "./volumes/ipfs1"
   "./volumes/ollama"


### PR DESCRIPTION
### Description

Add option to use CA certificate for connection to SMTP server. To activate:
- Set `USE_STORED_CERTIFICATE` in `.env` to true
- Save `ca.crt` in `volumes/general/smtp/`

## Testing Instructions

Test the connection to a SMTP server that didn't work before, but now with a stored CA certificate.
Also make sure that the documentation is correct.

### Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix

### Related Issue

Closes #388 
